### PR TITLE
Fix filepath in run_program.ado

### DIFF
--- a/ado/labmask.ado
+++ b/ado/labmask.ado
@@ -1,5 +1,8 @@
 *! NJC 1.0.0 20 August 2002
 * values of -values-, or its value labels, to be labels of -varname-
+
+cap program drop labmask
+
 program def labmask, sortpreserve 
 	version 7 
 	syntax varname(numeric) [if] [in], /* 

--- a/ado/run_program.ado
+++ b/ado/run_program.ado
@@ -9,7 +9,6 @@ program define run_program, rclass
 syntax anything(name=program id="Program")
 
 * Set file paths
-global welfare_git "${welfare_git}/Welfare"
 global welfare_dropbox "${welfare_files}"
 global assumptions "${welfare_files}/MVPF_Calculations/program_assumptions"
 global program_folder "${welfare_git}/programs/functioning"
@@ -17,10 +16,10 @@ global ado_files "${welfare_git}/ado"
 global data_derived "${welfare_files}/Data/derived"
 global input_data "${welfare_files}/data/inputs"
 global correlation=1
-local ado_files : dir "${welfare_git}/welfare/ado" files "*.ado"
+local ado_files : dir "${welfare_git}/ado" files "*.ado"
 
 foreach file in `ado_files' {
-	if regexm("`file'","run_program")==0 do "${welfare_git}/welfare/ado/`file'"
+	if regexm("`file'","run_program")==0 do "${welfare_git}/ado/`file'"
 }
 local program = lower("`program'")
 
@@ -81,6 +80,6 @@ if (strpos("`program'", "cpc")) & regexm("`program'","ui")==0 {
 }
 global draw_number = 0
 
-do "${welfare_git}/welfare/programs/functioning/`do_file'.do" `program' no uncorrected
+do "${welfare_git}/programs/functioning/`do_file'.do" `program' no uncorrected
 
 end


### PR DESCRIPTION
The global `welfare_git` should point to the global `welfare_git` as set in `metafile.do` and not to the subfolder `Welfare`. Thank you, @bgoldman930, for spotting this error. This fix does not affect any results but only improves usability of `run_program`.